### PR TITLE
feat: Implement API key storage in PWA

### DIFF
--- a/components/ApiKeyModal.tsx
+++ b/components/ApiKeyModal.tsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { ApiKeys } from '../types';
+
+interface ApiKeyModalProps {
+  onSave: (keys: ApiKeys) => void;
+}
+
+const ApiKeyModal: React.FC<ApiKeyModalProps> = ({ onSave }) => {
+  const [openai, setOpenai] = useState('');
+  const [google, setGoogle] = useState('');
+  const [searchEngineId, setSearchEngineId] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave({ openai, google, searchEngineId });
+  };
+
+  return (
+    <div className="fixed inset-0 bg-gray-800 bg-opacity-75 flex items-center justify-center z-50">
+      <div className="bg-gray-900 rounded-lg shadow-xl p-8 max-w-md w-full">
+        <h2 className="text-2xl font-bold text-white mb-4">Enter API Keys</h2>
+        <p className="text-gray-400 mb-6">
+          Please provide your API keys to use the full functionality of the application.
+        </p>
+        <form onSubmit={handleSubmit}>
+          <div className="mb-4">
+            <label htmlFor="openai" className="block text-gray-300 mb-2">OpenAI API Key</label>
+            <input
+              id="openai"
+              type="password"
+              value={openai}
+              onChange={(e) => setOpenai(e.target.value)}
+              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="google" className="block text-gray-300 mb-2">Google Cloud API Key</label>
+            <input
+              id="google"
+              type="password"
+              value={google}
+              onChange={(e) => setGoogle(e.target.value)}
+              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <div className="mb-6">
+            <label htmlFor="searchEngineId" className="block text-gray-300 mb-2">Google Search Engine ID</label>
+            <input
+              id="searchEngineId"
+              type="password"
+              value={searchEngineId}
+              onChange={(e) => setSearchEngineId(e.target.value)}
+              className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              required
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-md transition duration-300"
+          >
+            Save Keys
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ApiKeyModal;

--- a/services/apiKeyService.ts
+++ b/services/apiKeyService.ts
@@ -1,0 +1,69 @@
+import { ApiKeys } from '../types';
+
+const DB_NAME = 'VoiceAssistantDB';
+const STORE_NAME = 'apiKeys';
+const DB_VERSION = 2; // Increment version to trigger onupgradeneeded
+
+let db: IDBDatabase | null = null;
+
+const initDB = (): Promise<IDBDatabase> => {
+  return new Promise((resolve, reject) => {
+    if (db) {
+      return resolve(db);
+    }
+
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = (event) => {
+      console.error('IndexedDB error:', event);
+      reject('IndexedDB error');
+    };
+
+    request.onsuccess = (event) => {
+      db = (event.target as IDBOpenDBRequest).result;
+      resolve(db);
+    };
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+      }
+    };
+  });
+};
+
+export const saveApiKeys = async (keys: ApiKeys): Promise<void> => {
+  const db = await initDB();
+  const transaction = db.transaction(STORE_NAME, 'readwrite');
+  const store = transaction.objectStore(STORE_NAME);
+  // Use a fixed key 'userApiKeys' to always update the same record.
+  store.put({ ...keys, id: 'userApiKeys' });
+
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => {
+      resolve();
+    };
+    transaction.onerror = (event) => {
+      console.error('Failed to save API keys:', event);
+      reject('Failed to save API keys');
+    };
+  });
+};
+
+export const getApiKeys = async (): Promise<ApiKeys | null> => {
+  const db = await initDB();
+  const transaction = db.transaction(STORE_NAME, 'readonly');
+  const store = transaction.objectStore(STORE_NAME);
+  const request = store.get('userApiKeys');
+
+  return new Promise((resolve, reject) => {
+    request.onerror = (event) => {
+      console.error('Failed to get API keys:', event);
+      reject('Failed to get API keys');
+    };
+    request.onsuccess = () => {
+      resolve(request.result as ApiKeys | null);
+    };
+  });
+};

--- a/services/openaiService.ts
+++ b/services/openaiService.ts
@@ -1,15 +1,13 @@
 // This function uses your main OpenAI API key to securely generate a short-lived
 // client token for the browser to use. This is the recommended approach from the
 // OpenAI Agents SDK documentation.
-export const getClientToken = async () => {
-    const API_KEY = import.meta.env.VITE_OPENAI_API_KEY;
-
-    if (!API_KEY || API_KEY === 'your-openai-api-key-here') {
-      throw new Error('OpenAI API key is missing. Please add it to your .env file.');
+export const getClientToken = async (apiKey: string) => {
+    if (!apiKey) {
+      throw new Error('OpenAI API key is missing.');
     }
     
     // Validate API key format
-    if (!API_KEY.startsWith('sk-')) {
+    if (!apiKey.startsWith('sk-')) {
       throw new Error('Invalid API key format. API key should start with "sk-"');
     }
 
@@ -17,7 +15,7 @@ export const getClientToken = async () => {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
-            "Authorization": `Bearer ${API_KEY}`,
+            "Authorization": `Bearer ${apiKey}`,
         },
         body: JSON.stringify({
             "session": {

--- a/services/webSearchService.ts
+++ b/services/webSearchService.ts
@@ -1,9 +1,6 @@
 // Web search service for the Realtime API using Google Custom Search
-const GOOGLE_API_KEY = import.meta.env.VITE_GOOGLE_API_KEY;
-const GOOGLE_CSE_ID = import.meta.env.VITE_GOOGLE_CSE_ID;
-
-export const webSearch = async (query: string): Promise<string> => {
-  if (!GOOGLE_API_KEY || !GOOGLE_CSE_ID || GOOGLE_API_KEY === 'your-google-cloud-api-key-here' || GOOGLE_CSE_ID === 'your-google-cse-id-here') {
+export const webSearch = async (query: string, apiKey: string, cseId: string): Promise<string> => {
+  if (!apiKey || !cseId) {
     console.warn('Google API Key or CSE ID is missing. The web search tool will not be available.');
     return "The web search tool is not configured. Please ask the user to configure the Google API Key and CSE ID.";
   }
@@ -11,7 +8,7 @@ export const webSearch = async (query: string): Promise<string> => {
   try {
     console.log('Performing Google Custom Search for:', query);
 
-    const url = `https://www.googleapis.com/customsearch/v1?key=${GOOGLE_API_KEY}&cx=${GOOGLE_CSE_ID}&q=${encodeURIComponent(query)}&num=3`;
+    const url = `https://www.googleapis.com/customsearch/v1?key=${apiKey}&cx=${cseId}&q=${encodeURIComponent(query)}&num=3`;
 
     const response = await fetch(url);
 

--- a/types.ts
+++ b/types.ts
@@ -16,5 +16,11 @@ export interface SavedConversation {
   assistantAudioUrl?: string;
 }
 
+export interface ApiKeys {
+    openai: string;
+    google: string;
+    searchEngineId: string;
+}
+
 // Based on OpenAI Realtime API documentation
 export type OpenAIVoice = "alloy" | "echo" | "fable" | "onyx" | "nova" | "shimmer" | "cedar" | "marin";


### PR DESCRIPTION
This feature prompts the user for API keys (Google Cloud, Search Engine ID, and OpenAI) on the first use and saves them in IndexedDB for future sessions.

- Created an ApiKeyModal component to get keys from the user.
- Added an apiKeyService to manage storing and retrieving keys from IndexedDB.
- Updated the main App component to check for saved keys on startup and show the modal if they are not found.
- Refactored the getClientToken and webSearch services to accept API keys as parameters instead of reading them from environment variables.