### PR TITLE
fix: Resolve stale closure bug for API keys

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -703,7 +703,7 @@ Your goal is to be genuinely helpful while sounding natural and human-like in co
       setError(`Failed to start: ${userFriendlyError}`);
       setStatus('idle');
     }
-  }, [selectedVoice, handleTranscript]);
+  }, [selectedVoice, handleTranscript, apiKeys]);
 
   const stopConversation = useCallback(async (isClosedByServer = false) => {
     console.log('stopConversation called, status:', status, 'isClosedByServer:', isClosedByServer);


### PR DESCRIPTION
This commit fixes a bug where the `startConversation` function would not have access to the latest `apiKeys` state, causing an "API keys are not set" error even after the user had entered them.

The `apiKeys` state has been added to the dependency array of the `useCallback` hook for `startConversation`. This ensures that the function is recreated with the correct state whenever the API keys are updated, preventing the stale closure.