### PR TITLE
fix: Correct session configuration for turn detection

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -175,13 +175,15 @@ Your goal is to be genuinely helpful while sounding natural and human-like in co
         model: 'gpt-realtime',
         transport: 'webrtc' as const, // Try WebRTC first, fallback to WebSocket if needed
         config: {
-          turnDetection: {
-            type: 'semantic_vad',
-            eagerness: 'low',
-            silence_duration_ms: 2000, // Increase silence duration to 2 seconds
-            interruptResponse: false,
-          },
           audio: {
+            input: {
+              turnDetection: {
+                type: 'semantic_vad',
+                eagerness: 'low',
+                silence_duration_ms: 2000, // Increase silence duration to 2 seconds
+                interruptResponse: false,
+              },
+            },
             output: {
               voice: selectedVoice
             }


### PR DESCRIPTION
This commit fixes an `invalid_request_error` caused by an incorrect parameter location in the session configuration. The `turnDetection` object was previously at the root of the `config` object, but the API expects it to be nested under `config.audio.input`.

The `sessionConfig` object in `App.tsx` has been updated to reflect the correct structure. This resolves the error that was being thrown on session creation, which prevented the UI from updating its status correctly.