### PR TITLE
feat: Temporarily remove turnDetection configuration

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -176,14 +176,6 @@ Your goal is to be genuinely helpful while sounding natural and human-like in co
         transport: 'webrtc' as const, // Try WebRTC first, fallback to WebSocket if needed
         config: {
           audio: {
-            input: {
-              turnDetection: {
-                type: 'semantic_vad',
-                eagerness: 'low',
-                silence_duration_ms: 2000, // Increase silence duration to 2 seconds
-                interruptResponse: false,
-              },
-            },
             output: {
               voice: selectedVoice
             }


### PR DESCRIPTION
This commit removes the `turnDetection` configuration from the `sessionConfig` object in `App.tsx` as a debugging measure.

This is intended to isolate a bug that is causing an `invalid_request_error` on session creation. By removing this block, we can determine if the error is contained within these parameters.