### PR TITLE
fix: Add empty audio input object to session config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -176,6 +176,7 @@ Your goal is to be genuinely helpful while sounding natural and human-like in co
         transport: 'webrtc' as const, // Try WebRTC first, fallback to WebSocket if needed
         config: {
           audio: {
+            input: {},
             output: {
               voice: selectedVoice
             }


### PR DESCRIPTION
This commit adds an empty `input: {}` object to the `config.audio` block in `sessionConfig`.

After removing the `turnDetection` parameters for debugging, the session was failing to connect silently. This change is based on the theory that the `audio.input` object is required, even if it has no parameters. This should allow the WebRTC connection to be established successfully.